### PR TITLE
IPv6-Erfahrungen ergänzen und Cursor-Command-Docs hinzufügen

### DIFF
--- a/.cursor/commands/bun_tests.md
+++ b/.cursor/commands/bun_tests.md
@@ -1,0 +1,13 @@
+Teste die Anwendung mit Bun.
+
+Führe nacheinander folgende Schritte aus:
+1. `bun run lint`
+   - Analysiere alle Lint-Fehler.
+   - Behebe die Fehler direkt im Code, bis der Lint-Durchlauf ohne Fehler erfolgreich ist.
+
+2. `bun run build`
+   - Analysiere alle Build-Fehler.
+   - Behebe die Fehler direkt im Code, bis der Build erfolgreich durchläuft.
+
+Wiederhole die Schritte automatisch, falls nach Fixes neue Fehler auftreten.
+Am Ende müssen sowohl `bun run lint` als auch `bun run build` ohne Fehler durchlaufen.

--- a/.cursor/commands/changelog.md
+++ b/.cursor/commands/changelog.md
@@ -1,7 +1,3 @@
----
-Description: always apply this rule to ensure that the [Unreleased] section in Changelog.md is updated whenever any changes are made or committed.
-alwaysApply: true
----
 ## Änderungen im Changelog eintragen
 
 ### Mehrsprachige Changelog-Struktur:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Replaced profile, about, and project showcase images with WebP assets for faster loading times
 - Removed GitHub discovery link from the projects section call-to-action
+- Enhanced experience descriptions with IPv6 implementation details and achievements
+- Added IPv6 tags to relevant work experiences (DEGIT AG, DVAG Network Security, Schwarz IT, DVAG Linux Systems)
 
 ### Fixed
 - Ensured CV PDF/DOCX downloads always include the current date in the filename

--- a/CHANGELOG_DE.md
+++ b/CHANGELOG_DE.md
@@ -13,6 +13,8 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Changed (Geändert)
 - Profil-, About- und Projektbilder auf WebP umgestellt für schnellere Ladezeiten
 - GitHub-Link zum Entdecken weiterer Projekte aus dem Projekte-Bereich entfernt
+- Erfahrungsbeschreibungen um IPv6-Implementierungsdetails und Erfolge erweitert
+- IPv6-Tags zu relevanten Berufserfahrungen hinzugefügt (DEGIT AG, DVAG Network Security, Schwarz IT, DVAG Linux Systems)
 
 ### Fixed (Behoben)
 - CV-PDF/DOCX-Downloads nutzen jetzt immer den aktuellen Datumsteil im Dateinamen

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,3 +1,5 @@
 [test]
 preload = ["./src/setupBunTests.ts"]
 
+
+

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -520,8 +520,8 @@ export const siteContent: SiteContent = {
         {
           type: "text",
           text: {
-            en: "Oversees the design of secure, redundant infrastructures including firewall concepts, VPN solutions, and backup strategies.",
-            de: "Überwacht die Konzeption sicherer, redundanter Infrastrukturen einschließlich Firewall-Konzepten, VPN-Lösungen und Backup-Strategien.",
+            en: "Oversees the design of secure, redundant infrastructures including firewall concepts, VPN solutions (IPv6, Zero Trust, Zero-Config VPN, etc.) and backup strategies.",
+            de: "Überwacht die Konzeption sicherer, redundanter Infrastrukturen einschließlich Firewall-Konzepten, VPN-Lösungen (IPv6, Zero Trust, Zero-Config VPN, etc.) und Backup-Strategien.",
           },
         },
         {
@@ -563,6 +563,7 @@ export const siteContent: SiteContent = {
         { en: "Cloudflare", de: "Cloudflare" },
         { en: "Supabase", de: "Supabase" },
         { en: "Azure", de: "Azure" },
+        { en: "IPv6", de: "IPv6" },
       ],
     },
     {
@@ -659,6 +660,13 @@ export const siteContent: SiteContent = {
         {
           type: "achievement",
           text: {
+            en: "Implementation of IPv6 across the organization, future-proofing the network.",
+            de: "Implementierung von IPv6 im gesamten Unternehmen, Zukunftssicherung des Netzwerks.",
+          },
+        },
+        {
+          type: "achievement",
+          text: {
             en: "Rolled out secure SD-WAN connectivity for branch offices, improving stability and visibility of network communication.",
             de: "Ausrollen sicherer SD-WAN-Anbindungen für Außenstandorte zur Verbesserung von Stabilität und Transparenz der Netzwerkkommunikation.",
           },
@@ -677,6 +685,7 @@ export const siteContent: SiteContent = {
         { en: "IPSec", de: "IPSec" },
         { en: "Proxy", de: "Proxy" },
         { en: "Azure", de: "Azure" },
+        { en: "IPv6", de: "IPv6" },
         { en: "Change Management", de: "Change Management" },
         { en: "Documentation", de: "Dokumentation" },
         { en: "Cloud Security", de: "Cloud Security" },
@@ -808,6 +817,7 @@ export const siteContent: SiteContent = {
         { en: "High Availability", de: "Hochverfügbarkeit" },
         { en: "Puppet", de: "Puppet" },
         { en: "Ansible", de: "Ansible" },
+        { en: "IPv6", de: "IPv6" },
       ],
     },
     {
@@ -852,6 +862,13 @@ export const siteContent: SiteContent = {
             de: "Aufbau einer Mail-Archivierungsplattform, die Langzeit-Compliance sicherstellte und eDiscovery vereinfachte.",
           },
         },
+        {
+          type: "achievement",
+          text: {
+            en: "Design and implementation of IPv6 at the network perimeter to ensure external accessibility.",
+            de: "Konzeption und Implementierung von IPv6 im Netzwerk-Perimeter zur Sicherstellung der externen Erreichbarkeit.",
+          },
+        },
       ],
       tags: [
         { en: "Linux", de: "Linux" },
@@ -860,6 +877,7 @@ export const siteContent: SiteContent = {
         { en: "Storage", de: "Storage" },
         { en: "Puppet", de: "Puppet" },
         { en: "Ceph", de: "Ceph" },
+        { en: "IPv6", de: "IPv6" },
       ],
     },
   ],


### PR DESCRIPTION
- Experience-Texte um IPv6-Details/Achievements erweitert und IPv6-Tags ergänzt
- CHANGELOG (EN/DE) entsprechend aktualisiert
- Neue Cursor-Commands für Bun-Tests und Changelog-Pflege hinzugefügt
- bunfig.toml mit zusätzlichem Leerraum bereinigt/angepasst
