### PR TITLE
chore: update bun dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -883,7 +883,7 @@
 
     "lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
-    "lucide-react": ["lucide-react@1.9.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-6qVAmbgCjcJz7sAGSPSSJ++RAwjlK2XCbRrZKv63Ciko1KT8jX0//CXxgI3jg2HlJu8tADqdYlNDebmYjeoruA=="],
+    "lucide-react": ["lucide-react@1.11.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-UOhjdztXCgdBReRcIhsvz2siIBogfv/lhJEIViCpLt924dO+GDms9T7DNoucI23s6kEPpe988m5N0D2ajnzb2g=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "docx": "9.6.1",
     "embla-carousel-react": "8.6.0",
     "input-otp": "1.4.2",
-    "lucide-react": "1.9.0",
+    "lucide-react": "1.11.0",
     "lz-string": "1.5.0",
     "next": "16.2.4",
     "next-themes": "0.4.6",


### PR DESCRIPTION
## Summary
- Update `lucide-react` from `1.9.0` to `1.11.0`
- Refresh `bun.lock`

## Validation
- `bun run lint`
- `bun run test`
- `bun run build`
- Screenshot comparison across `/`, `/404`, `/cv`, `/imprint`, `/privacy`, `/sitemap` in desktop and mobile: 0 failures; max diff 0.0002% on mobile `/`

## Notes
- No regression fixes or dependency pins were required.