### PR TITLE
Expose dev server over Tailnet HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,15 @@ Personal portfolio built with **Next.js 16**, **React 19**, **TypeScript**, **Ta
 
 ```bash
 bun install
-bun run dev   # starts Next.js on http://localhost:3000
+bun run dev   # starts Next.js and exposes it at https://lyra.tailb44a3.ts.net/
 ```
 
 ## Useful Scripts
 
-- `bun run dev` – start the Next.js dev server
+- `bun run dev` – start the Next.js dev server and expose it through Tailscale Serve at `https://lyra.tailb44a3.ts.net/`
+- `bun run dev:local` – start the Next.js dev server without configuring Tailscale Serve
+- `bun run dev:tailnet:status` – show the active Tailscale Serve configuration
+- `bun run dev:tailnet:off` – disable the HTTPS proxy on port 443
 - `bun run lint` – lint the project with Oxlint
 - `bun run test` – run unit tests with Vitest
 - `bun run build` – create a production build

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,7 @@ const projectRoot = path.dirname(fileURLToPath(import.meta.url));
 const nextConfig = {
   reactStrictMode: true,
   typedRoutes: true,
+  allowedDevOrigins: ["lyra.tailb44a3.ts.net"],
   async headers() {
     return [
       {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "type": "module",
   "packageManager": "bun@1.3.4",
   "scripts": {
-    "dev": "next dev",
+    "dev": "bun scripts/dev-tailnet.ts",
+    "dev:local": "next dev",
+    "dev:tailnet:off": "tailscale serve --https=443 off",
+    "dev:tailnet:status": "tailscale serve status",
     "build": "next build",
     "start": "next start",
     "lint": "oxlint --react-plugin --nextjs-plugin --vitest-plugin --import-plugin --deny-warnings .",

--- a/scripts/dev-tailnet.ts
+++ b/scripts/dev-tailnet.ts
@@ -1,0 +1,87 @@
+import { spawn, spawnSync } from "node:child_process";
+
+const port = process.env.PORT ?? "3000";
+const host = process.env.DEV_HOST ?? "0.0.0.0";
+const localTarget = `http://127.0.0.1:${port}`;
+
+function commandExists(command: string) {
+  const result = spawnSync("sh", ["-lc", `command -v ${command}`], {
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+
+  return result.status === 0;
+}
+
+function getTailnetUrl() {
+  const result = spawnSync("tailscale", ["status", "--json"], {
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+
+  if (result.status !== 0) {
+    return "https://lyra.tailb44a3.ts.net/";
+  }
+
+  try {
+    const status = JSON.parse(result.stdout) as {
+      Self?: { DNSName?: string };
+    };
+    const dnsName = status.Self?.DNSName?.replace(/\.$/, "");
+
+    return dnsName ? `https://${dnsName}/` : "https://lyra.tailb44a3.ts.net/";
+  } catch {
+    return "https://lyra.tailb44a3.ts.net/";
+  }
+}
+
+function configureTailnetServe() {
+  if (!commandExists("tailscale")) {
+    console.warn("tailscale CLI not found; starting local Next.js dev server only.");
+    return;
+  }
+
+  const result = spawnSync(
+    "tailscale",
+    ["serve", "--bg", "--yes", "--https=443", localTarget],
+    {
+      encoding: "utf8",
+      stdio: "pipe",
+    },
+  );
+
+  if (result.status !== 0) {
+    console.warn(result.stderr.trim() || result.stdout.trim());
+    console.warn("Could not configure Tailscale Serve; starting Next.js anyway.");
+    return;
+  }
+
+  console.log(`Tailnet HTTPS: ${getTailnetUrl()} -> ${localTarget}`);
+}
+
+configureTailnetServe();
+
+const nextDev = spawn("bun", ["x", "next", "dev", "-H", host, "-p", port], {
+  stdio: "inherit",
+});
+
+const signalExitCodes: Partial<Record<NodeJS.Signals, number>> = {
+  SIGINT: 130,
+  SIGTERM: 143,
+};
+
+function stop(signal: NodeJS.Signals) {
+  nextDev.kill(signal);
+}
+
+process.on("SIGINT", () => stop("SIGINT"));
+process.on("SIGTERM", () => stop("SIGTERM"));
+
+nextDev.on("exit", (code, signal) => {
+  if (signal) {
+    process.exit(signalExitCodes[signal] ?? 1);
+    return;
+  }
+
+  process.exit(code ?? 0);
+});


### PR DESCRIPTION
Closes #89

## Summary

- route the default `bun run dev` flow through a small Bun wrapper that configures Tailscale Serve for `https://lyra.tailb44a3.ts.net/`
- keep Next.js running locally on port 3000 while Tailscale terminates HTTPS on port 443 and proxies to `http://127.0.0.1:3000`
- add `lyra.tailb44a3.ts.net` to `allowedDevOrigins` so Next.js dev resources are not blocked over the Tailnet hostname
- document `dev:local`, `dev:tailnet:status`, and `dev:tailnet:off`

## Why

Remote code-box development makes `localhost` inconvenient because the app is running on the remote machine rather than the user's browser device. Using Tailscale Serve gives the dev server a stable HTTPS URL inside the tailnet without requiring a self-signed Next.js certificate.

## Validation

- `bun run lint`
- `bun run test -- --run`
- `bun run build`
- `bun run dev`
- `curl -I https://lyra.tailb44a3.ts.net/` returned `HTTP/2 200`
- checked the dev log after requesting through the Tailnet URL; the earlier blocked cross-origin dev-resource warning is gone after adding `allowedDevOrigins`