### PR TITLE
Bind Tailnet dev server to loopback

### DIFF
--- a/scripts/dev-tailnet.ts
+++ b/scripts/dev-tailnet.ts
@@ -1,8 +1,8 @@
 import { spawn, spawnSync } from "node:child_process";
 
 const port = process.env.PORT ?? "3000";
-const host = process.env.DEV_HOST ?? "0.0.0.0";
-const localTarget = `http://127.0.0.1:${port}`;
+const host = "127.0.0.1";
+const localTarget = `http://${host}:${port}`;
 
 function commandExists(command: string) {
   const result = spawnSync("sh", ["-lc", `command -v ${command}`], {


### PR DESCRIPTION
## Summary

- address the Codex review feedback from #90 by binding Next.js dev to the same loopback host that Tailscale Serve proxies to
- keep the Tailnet HTTPS target as `http://127.0.0.1:${port}` so the advertised `https://lyra.tailb44a3.ts.net/` URL cannot point at a different bind target

## Why

Codex noted that the dev server bind host and the Tailscale Serve proxy target should stay aligned. Binding Next directly to `127.0.0.1` is sufficient because Tailscale Serve is the remote-facing HTTPS endpoint.

## Validation

- `bun run lint`
- `bun run test -- --run`
- `bun run build`
- `bun run dev`
- `curl -I https://lyra.tailb44a3.ts.net/` returned `HTTP/2 200`