### PR TITLE
Harden Tailnet dev startup

### DIFF
--- a/PORTLESS_FINAL.md
+++ b/PORTLESS_FINAL.md
@@ -1,0 +1,216 @@
+# Tailnet dev server recipe
+
+## Purpose
+
+Use this recipe when a repository should support one default command:
+
+```sh
+bun run dev
+```
+
+The command should:
+
+- start the framework dev server on `127.0.0.1` for local tools and agents;
+- expose the same app through Tailscale HTTPS on port `443`;
+- print a clickable Tailnet URL in the terminal output;
+- avoid Portless owning Tailnet port `443`.
+
+This pattern is intentionally repo-local. Different frameworks need different
+host, origin, HMR, or allowed-host settings.
+
+## Recommended architecture
+
+Keep the app server local and let Tailscale own HTTPS:
+
+```text
+Browser in tailnet
+  -> https://<machine>.<tailnet>.ts.net/
+  -> tailscale serve --https=443
+  -> http://127.0.0.1:<app-port>
+  -> framework dev server
+```
+
+For Next.js, the app command should bind only to loopback:
+
+```sh
+next dev -H 127.0.0.1 -p "${PORT:-3000}"
+```
+
+The Tailscale command should proxy that local target:
+
+```sh
+tailscale serve --bg --yes --https=443 "http://127.0.0.1:${PORT:-3000}"
+```
+
+## Why not Portless as the default
+
+Do not make this the default:
+
+```sh
+portless <app-name> --tailscale bun run dev
+```
+
+That can recurse if `bun run dev` already starts the repo's Tailnet wrapper.
+It can also leave Portless owning HTTPS port `443`, which makes the Tailnet URL
+return a Portless `404` with `x-portless: 1` instead of the app.
+
+Use Portless separately only after verifying it routes the Tailnet hostname
+correctly for that repo.
+
+## Wrapper behavior
+
+Create a wrapper script, for example `scripts/dev-tailnet.ts`, and point
+`package.json` `dev` at it:
+
+```json
+{
+  "scripts": {
+    "dev": "bun scripts/dev-tailnet.ts",
+    "dev:local": "next dev",
+    "dev:tailnet:off": "tailscale serve --https=443 off",
+    "dev:tailnet:status": "tailscale serve status"
+  }
+}
+```
+
+The wrapper should do this in order:
+
+1. Resolve the current Tailscale DNS name with `tailscale status --json`.
+2. Export a framework-specific Tailnet host environment variable, such as
+   `DEV_TAILNET_HOST`.
+3. Stop Portless if it is installed:
+
+   ```sh
+   portless proxy stop
+   ```
+
+4. Reset existing Tailscale Serve state:
+
+   ```sh
+   tailscale serve reset
+   ```
+
+5. Configure Tailscale Serve on port `443`:
+
+   ```sh
+   tailscale serve --bg --yes --https=443 "http://127.0.0.1:${PORT:-3000}"
+   ```
+
+6. Print both URLs before starting or immediately before framework output:
+
+   ```text
+   Local: http://127.0.0.1:3000
+   Tailnet HTTPS: https://lyra.tailb44a3.ts.net/ -> http://127.0.0.1:3000
+   ```
+
+7. Start the framework dev server on `127.0.0.1`.
+
+## Next.js configuration
+
+For Next.js, make the Tailnet host allowed during development:
+
+```js
+const tailnetHost = process.env.DEV_TAILNET_HOST ?? "lyra.tailb44a3.ts.net";
+
+const nextConfig = {
+  allowedDevOrigins: [tailnetHost],
+};
+
+export default nextConfig;
+```
+
+Keep the wrapper responsible for setting `DEV_TAILNET_HOST` before spawning
+Next.js.
+
+## Tests to add
+
+Add focused tests around the wrapper helpers instead of only testing by hand.
+Useful assertions:
+
+- Next.js dev args include `-H 127.0.0.1`.
+- Tailscale Serve args include `--https=443`.
+- The wrapper prepares `portless proxy stop`.
+- The wrapper prepares `tailscale serve reset`.
+- Tailscale DNS names ending with `.` are normalized.
+- Startup output contains both the local URL and Tailnet HTTPS URL.
+- Framework config accepts the current Tailnet host.
+
+Example expected values:
+
+```ts
+expect(buildNextDevArgs("3000")).toEqual([
+  "x",
+  "next",
+  "dev",
+  "-H",
+  "127.0.0.1",
+  "-p",
+  "3000",
+]);
+
+expect(buildTailnetServeArgs("http://127.0.0.1:3000")).toEqual([
+  "serve",
+  "--bg",
+  "--yes",
+  "--https=443",
+  "http://127.0.0.1:3000",
+]);
+```
+
+## Verification checklist
+
+After implementing in a repo, run:
+
+```sh
+bun run lint
+bun run test -- --run
+bun run typecheck
+```
+
+Then do a live smoke:
+
+```sh
+bun run dev
+curl -k -I http://127.0.0.1:3000/
+curl -k -I https://lyra.tailb44a3.ts.net/
+curl -k -I https://lyra.tailb44a3.ts.net/_next/static/development/_buildManifest.js
+tailscale serve status
+sudo lsof -nP -iTCP:443 -sTCP:LISTEN
+```
+
+Expected results:
+
+- local URL returns `200`;
+- Tailnet URL returns `200`;
+- Next.js static chunks return `200`;
+- `tailscale serve status` shows `/ proxy http://127.0.0.1:3000`;
+- `lsof` shows Tailscale owning `*:443`, not a Node/Portless process.
+
+If `https://<tailnet-host>/` returns `404` with `x-portless: 1`, Portless is
+still answering on `443`. Stop it with:
+
+```sh
+portless proxy stop
+```
+
+Then rerun `bun run dev`.
+
+## Framework notes
+
+For Next.js:
+
+- bind dev server to `127.0.0.1`;
+- set `allowedDevOrigins` to the Tailnet host;
+- verify static chunks under `/_next/static/...`.
+
+For Vite or Astro:
+
+- bind the app to `127.0.0.1`;
+- set the Tailnet host in `allowedHosts`;
+- configure HMR for `wss` and port `443` if browser updates fail over HTTPS.
+
+For any framework:
+
+- keep the framework off public TLS;
+- let Tailscale terminate HTTPS;
+- make the printed Tailnet URL the URL agents and humans should click.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,12 +2,13 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const projectRoot = path.dirname(fileURLToPath(import.meta.url));
+const tailnetHost = process.env.DEV_TAILNET_HOST ?? "lyra.tailb44a3.ts.net";
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   typedRoutes: true,
-  allowedDevOrigins: ["lyra.tailb44a3.ts.net"],
+  allowedDevOrigins: [tailnetHost],
   async headers() {
     return [
       {

--- a/scripts/dev-tailnet.ts
+++ b/scripts/dev-tailnet.ts
@@ -1,10 +1,13 @@
 import { spawn, spawnSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
 
 const port = process.env.PORT ?? "3000";
+const tailnetHttpsPort = "443";
 const host = "127.0.0.1";
 const localTarget = `http://${host}:${port}`;
+const fallbackTailnetUrl = "https://lyra.tailb44a3.ts.net/";
 
-function commandExists(command: string) {
+export function commandExists(command: string) {
   const result = spawnSync("sh", ["-lc", `command -v ${command}`], {
     encoding: "utf8",
     stdio: "pipe",
@@ -13,37 +16,104 @@ function commandExists(command: string) {
   return result.status === 0;
 }
 
-function getTailnetUrl() {
+export function parseTailnetUrl(stdout: string) {
+  try {
+    const status = JSON.parse(stdout) as {
+      Self?: { DNSName?: string };
+    };
+    const dnsName = status.Self?.DNSName?.replace(/\.$/, "");
+
+    return dnsName ? `https://${dnsName}/` : fallbackTailnetUrl;
+  } catch {
+    return fallbackTailnetUrl;
+  }
+}
+
+export function getTailnetUrl() {
   const result = spawnSync("tailscale", ["status", "--json"], {
     encoding: "utf8",
     stdio: "pipe",
   });
 
   if (result.status !== 0) {
-    return "https://lyra.tailb44a3.ts.net/";
+    return fallbackTailnetUrl;
   }
 
-  try {
-    const status = JSON.parse(result.stdout) as {
-      Self?: { DNSName?: string };
-    };
-    const dnsName = status.Self?.DNSName?.replace(/\.$/, "");
+  return parseTailnetUrl(result.stdout);
+}
 
-    return dnsName ? `https://${dnsName}/` : "https://lyra.tailb44a3.ts.net/";
-  } catch {
-    return "https://lyra.tailb44a3.ts.net/";
+export function formatStartupUrls({
+  localTarget,
+  tailnetUrl,
+}: {
+  localTarget: string;
+  tailnetUrl: string;
+}) {
+  return [
+    `Local: ${localTarget}`,
+    `Tailnet HTTPS: ${tailnetUrl} -> ${localTarget}`,
+  ];
+}
+
+export function buildNextDevArgs(port: string) {
+  return ["x", "next", "dev", "-H", host, "-p", port];
+}
+
+export function buildPortlessProxyStopArgs() {
+  return ["proxy", "stop"];
+}
+
+export function buildTailnetServeResetArgs() {
+  return ["serve", "reset"];
+}
+
+export function buildTailnetServeArgs(target: string) {
+  return ["serve", "--bg", "--yes", `--https=${tailnetHttpsPort}`, target];
+}
+
+function stopPortlessProxy() {
+  if (!commandExists("portless")) {
+    return;
+  }
+
+  const result = spawnSync("portless", buildPortlessProxyStopArgs(), {
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+
+  if (result.status !== 0) {
+    console.warn(result.stderr.trim() || result.stdout.trim());
+    console.warn("Could not stop Portless proxy; Tailscale HTTPS on port 443 may fail.");
+  }
+}
+
+function resetTailnetServe() {
+  const result = spawnSync("tailscale", buildTailnetServeResetArgs(), {
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+
+  if (result.status !== 0) {
+    console.warn(result.stderr.trim() || result.stdout.trim());
+    console.warn("Could not reset Tailscale Serve; trying to configure it anyway.");
   }
 }
 
 function configureTailnetServe() {
+  const tailnetUrl = getTailnetUrl();
+
   if (!commandExists("tailscale")) {
     console.warn("tailscale CLI not found; starting local Next.js dev server only.");
+    console.log(formatStartupUrls({ localTarget, tailnetUrl }).join("\n"));
     return;
   }
 
+  stopPortlessProxy();
+  resetTailnetServe();
+
   const result = spawnSync(
     "tailscale",
-    ["serve", "--bg", "--yes", "--https=443", localTarget],
+    buildTailnetServeArgs(localTarget),
     {
       encoding: "utf8",
       stdio: "pipe",
@@ -53,35 +123,51 @@ function configureTailnetServe() {
   if (result.status !== 0) {
     console.warn(result.stderr.trim() || result.stdout.trim());
     console.warn("Could not configure Tailscale Serve; starting Next.js anyway.");
+    console.log(formatStartupUrls({ localTarget, tailnetUrl }).join("\n"));
     return;
   }
 
-  console.log(`Tailnet HTTPS: ${getTailnetUrl()} -> ${localTarget}`);
+  console.log(formatStartupUrls({ localTarget, tailnetUrl }).join("\n"));
 }
-
-configureTailnetServe();
-
-const nextDev = spawn("bun", ["x", "next", "dev", "-H", host, "-p", port], {
-  stdio: "inherit",
-});
 
 const signalExitCodes: Partial<Record<NodeJS.Signals, number>> = {
   SIGINT: 130,
   SIGTERM: 143,
 };
 
-function stop(signal: NodeJS.Signals) {
-  nextDev.kill(signal);
-}
+function run() {
+  const tailnetUrl = getTailnetUrl();
+  const tailnetHost = new URL(tailnetUrl).hostname;
 
-process.on("SIGINT", () => stop("SIGINT"));
-process.on("SIGTERM", () => stop("SIGTERM"));
+  process.env.DEV_TAILNET_HOST = tailnetHost;
 
-nextDev.on("exit", (code, signal) => {
-  if (signal) {
-    process.exit(signalExitCodes[signal] ?? 1);
-    return;
+  configureTailnetServe();
+
+  const nextDev = spawn("bun", buildNextDevArgs(port), {
+    env: {
+      ...process.env,
+      DEV_TAILNET_HOST: tailnetHost,
+    },
+    stdio: "inherit",
+  });
+
+  function stop(signal: NodeJS.Signals) {
+    nextDev.kill(signal);
   }
 
-  process.exit(code ?? 0);
-});
+  process.on("SIGINT", () => stop("SIGINT"));
+  process.on("SIGTERM", () => stop("SIGTERM"));
+
+  nextDev.on("exit", (code, signal) => {
+    if (signal) {
+      process.exit(signalExitCodes[signal] ?? 1);
+      return;
+    }
+
+    process.exit(code ?? 0);
+  });
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  run();
+}

--- a/src/tests/devTailnet.test.ts
+++ b/src/tests/devTailnet.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPortlessProxyStopArgs,
+  buildNextDevArgs,
+  buildTailnetServeArgs,
+  buildTailnetServeResetArgs,
+  formatStartupUrls,
+  parseTailnetUrl,
+} from "../../scripts/dev-tailnet";
+
+describe("dev tailnet startup", () => {
+  it("binds the Next.js dev server to the local loopback interface", () => {
+    expect(buildNextDevArgs("3000")).toEqual([
+      "x",
+      "next",
+      "dev",
+      "-H",
+      "127.0.0.1",
+      "-p",
+      "3000",
+    ]);
+  });
+
+  it("prepares Tailscale Serve on HTTPS port 443", () => {
+    expect(buildPortlessProxyStopArgs()).toEqual(["proxy", "stop"]);
+    expect(buildTailnetServeResetArgs()).toEqual(["serve", "reset"]);
+    expect(buildTailnetServeArgs("http://127.0.0.1:3000")).toEqual([
+      "serve",
+      "--bg",
+      "--yes",
+      "--https=443",
+      "http://127.0.0.1:3000",
+    ]);
+  });
+
+  it("parses the current Tailscale DNS name into an HTTPS URL", () => {
+    const status = JSON.stringify({
+      Self: {
+        DNSName: "lyra.tailb44a3.ts.net.",
+      },
+    });
+
+    expect(parseTailnetUrl(status)).toBe("https://lyra.tailb44a3.ts.net/");
+  });
+
+  it("prints both clickable local and Tailnet URLs", () => {
+    expect(
+      formatStartupUrls({
+        localTarget: "http://127.0.0.1:3000",
+        tailnetUrl: "https://lyra.tailb44a3.ts.net/",
+      }),
+    ).toEqual([
+      "Local: http://127.0.0.1:3000",
+      "Tailnet HTTPS: https://lyra.tailb44a3.ts.net/ -> http://127.0.0.1:3000",
+    ]);
+  });
+});

--- a/src/tests/nextConfig.test.ts
+++ b/src/tests/nextConfig.test.ts
@@ -1,10 +1,20 @@
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
 describe("next config", () => {
+  beforeAll(() => {
+    process.env.DEV_TAILNET_HOST = "codex.tailnet.example.ts.net";
+  });
+
   it("sets an explicit turbopack root for dev server resolution", async () => {
     const { default: nextConfig } = await import("../../next.config.mjs");
 
     expect(nextConfig.turbopack?.root).toBe(process.cwd());
+  });
+
+  it("allows the current Tailnet host during local development", async () => {
+    const { default: nextConfig } = await import("../../next.config.mjs");
+
+    expect(nextConfig.allowedDevOrigins).toContain("codex.tailnet.example.ts.net");
   });
 
   it("adds an RFC 8288 Link header on the homepage for agent discovery", async () => {


### PR DESCRIPTION
## Summary

Closes #106.

- harden `bun run dev` so the dev wrapper stops Portless, resets Tailscale Serve, configures HTTPS on port 443, and starts Next.js on `127.0.0.1`
- derive `allowedDevOrigins` from the detected Tailnet host
- add focused tests for Tailnet wrapper command construction, URL formatting, and the Next.js allowed origin
- add `PORTLESS_FINAL.md` as a reusable recipe for applying the same pattern in other repos

## Validation

- `bun run lint`
- `bun run test -- --run`
- `bun run typecheck`
- live smoke: `bun run dev`
- live smoke: `curl -k -I http://127.0.0.1:3000/` returned `200`
- live smoke: `curl -k -I https://lyra.tailb44a3.ts.net/` returned `200`
- live smoke: `sudo lsof -nP -iTCP:443 -sTCP:LISTEN` showed Tailscale owning port 443
