### PR TITLE
Resolve runtime, icon, and async leak follow-ups

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "0.0.0",
   "type": "module",
   "packageManager": "bun@1.3.4",
+  "engines": {
+    "node": "24.x"
+  },
   "scripts": {
     "dev": "bun scripts/dev-tailnet.ts",
     "dev:local": "next dev",
@@ -15,7 +18,8 @@
     "test": "vitest",
     "typecheck": "tsc --noEmit --incremental false --pretty false",
     "test:run": "vitest --run",
-    "check": "bun run lint && bun run typecheck && bun run test:run && bun run verify:generated && bun run build",
+    "test:leaks": "bash -o pipefail -c 'vitest --run --detect-async-leaks 2>&1 | tee /tmp/vitest-async-leaks.log; test ${PIPESTATUS[0]} -eq 0; ! grep -Eq \"(Async Leaks [1-9]|Leaks [1-9][0-9]* leaks)\" /tmp/vitest-async-leaks.log'",
+    "check": "bun run lint && bun run typecheck && bun run test:run && bun run test:leaks && bun run verify:generated && bun run build",
     "generate:cv": "bun scripts/generate-cv.tsx",
     "generate:sitemap": "bun scripts/generate-sitemap.cjs",
     "generate:llms": "bun scripts/generate-llms.ts",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,6 @@
 import Head from "next/head";
 import type { AppProps } from "next/app";
+import { LucideProvider } from "lucide-react";
 import { SettingsProvider } from "@/contexts/SettingsContext";
 import { Toaster } from "@/components/ui/toaster";
 
@@ -15,10 +16,12 @@ export default function MyApp({ Component, pageProps }: AppProps) {
           content="Christian Erben - Network Security & Linux Infrastructure Specialist portfolio."
         />
       </Head>
-      <SettingsProvider>
-        <Toaster />
-        <Component {...pageProps} />
-      </SettingsProvider>
+      <LucideProvider strokeWidth={2}>
+        <SettingsProvider>
+          <Toaster />
+          <Component {...pageProps} />
+        </SettingsProvider>
+      </LucideProvider>
     </>
   );
 }

--- a/src/pages/cv.tsx
+++ b/src/pages/cv.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, Suspense } from "react";
 import Link from "next/link";
+import { useRouter } from "next/router";
 import { useSettings } from "@/contexts/settings-hook";
 import { siteContent, SiteContent } from "@/content/content";
 import { Button } from "@/components/ui/button";
@@ -127,6 +128,7 @@ const CvDownloadButtons: React.FC<{
 };
 
 const CV = () => {
+  const router = useRouter();
   const { language, setLanguage, theme, setTheme, t } = useSettings();
   // Unicode-safe LZ compression + Base64 encoding/decoding using TextEncoder/TextDecoder
   const encodeData = (str: string): string => {
@@ -180,12 +182,13 @@ const CV = () => {
     );
   };
 
-  const getInitialCvData = (): SiteContent => {
+  const getInitialCvData = (asPath: string): SiteContent => {
     if (typeof window === 'undefined') {
       return siteContent;
     }
 
-    const hash = window.location.hash;
+    const hashIndex = asPath.indexOf("#");
+    const hash = hashIndex >= 0 ? asPath.slice(hashIndex) : window.location.hash;
     const savedData = hash.startsWith('#data=') ? hash.slice(6) : null;
 
     if (!savedData) {
@@ -208,7 +211,7 @@ const CV = () => {
 
   const [clickCount, setClickCount] = useState(0);
   const [editMode, setEditMode] = useState(false);
-  const [cvData, setCvData] = useState<SiteContent>(() => getInitialCvData());
+  const [cvData, setCvData] = useState<SiteContent>(() => getInitialCvData(router.asPath));
   const [includeCertificates, setIncludeCertificates] = useState(false);
   const isDefaultData = cvData === siteContent;
   const previewPdfHref = `/cv/christian_erben_cv_${language}${isDefaultData && includeCertificates ? "_with_certificates" : ""}.pdf#toolbar=0&navpanes=0`;

--- a/src/tests/pages/CV.test.tsx
+++ b/src/tests/pages/CV.test.tsx
@@ -88,7 +88,7 @@ const encodeHashData = (data: SiteContent) => {
   return window.btoa(binary);
 };
 
-const renderCVPage = (ctx?: Partial<SettingsContextType>) => {
+const renderCVPage = (ctx?: Partial<SettingsContextType>, asPath = "/cv") => {
   const context: SettingsContextType = {
     language: "en",
     theme: "light",
@@ -101,7 +101,7 @@ const renderCVPage = (ctx?: Partial<SettingsContextType>) => {
   return renderWithSettings(
     <CV />,
     context,
-    { pathname: "/cv", asPath: "/cv" }
+    { pathname: "/cv", asPath }
   );
 };
 
@@ -127,7 +127,6 @@ describe("CV page", () => {
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
-    window.location.hash = "";
   });
 
   afterAll(() => {
@@ -201,7 +200,7 @@ describe("CV page", () => {
   });
 
   it("keeps custom CV data on lazy generated DOCX downloads", async () => {
-    window.location.hash = `data=${encodeHashData({
+    const asPath = `/cv#data=${encodeHashData({
       ...siteContent,
       hero: {
         ...siteContent.hero,
@@ -209,7 +208,7 @@ describe("CV page", () => {
       },
     })}`;
 
-    renderCVPage();
+    renderCVPage(undefined, asPath);
 
     const user = userEvent.setup();
     const customDocxButtons = await screen.findAllByRole("button", { name: /Download DOCX/i });
@@ -220,13 +219,13 @@ describe("CV page", () => {
   });
 
   it("ignores URL hash data that does not match the CV content shape", () => {
-    window.location.hash = `data=${encodeHashData({
+    const asPath = `/cv#data=${encodeHashData({
       hero: {
         name: "Incomplete Candidate",
       },
     } as SiteContent)}`;
 
-    renderCVPage();
+    renderCVPage(undefined, asPath);
 
     expect(screen.getByRole("link", { name: /Download PDF/i })).toHaveAttribute(
       "href",

--- a/src/tests/toolingConfig.test.ts
+++ b/src/tests/toolingConfig.test.ts
@@ -8,6 +8,7 @@ const readJson = <T>(relativePath: string): T =>
 
 interface PackageJson {
   dependencies?: Record<string, string>;
+  engines?: Record<string, string>;
   scripts: Record<string, string>;
 }
 
@@ -21,6 +22,16 @@ describe("tooling configuration", () => {
 
     expect(pkg.scripts["verify:generated"]).toBe("bun scripts/verify-generated.ts");
     expect(pkg.scripts.check).toContain("bun run verify:generated");
+  });
+
+  it("keeps async leak detection and the Node runtime target explicit", () => {
+    const pkg = readJson<PackageJson>("package.json");
+    const appEntry = readFileSync(path.resolve(process.cwd(), "src/pages/_app.tsx"), "utf8");
+
+    expect(pkg.engines?.node).toBe("24.x");
+    expect(pkg.scripts["test:leaks"]).toContain("--detect-async-leaks");
+    expect(pkg.scripts.check).toContain("bun run test:leaks");
+    expect(appEntry).toContain("LucideProvider");
   });
 
   it("does not keep a stale Bun-native test preload beside the Vitest setup", () => {


### PR DESCRIPTION
## Summary
- add a Vercel-compatible explicit Node.js runtime target via `engines.node: 24.x`
- wrap the app with `LucideProvider` for centralized Lucide defaults
- make Vitest async leak detection part of `bun run check` and avoid happy-dom URL mutation leaks in CV tests

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test:run`
- `bun run test:leaks`
- `bun run check`

Closes #41
Closes #108
Closes #110