### PR TITLE
Harden dependency release visual checks

### DIFF
--- a/.codex/skills/christianerben-dependency-release/SKILL.md
+++ b/.codex/skills/christianerben-dependency-release/SKILL.md
@@ -5,9 +5,9 @@ description: End-to-end dependency update and release workflow for the christian
 
 # Christianerben Dependency Release
 
-Use this skill to perform a full dependency release for `/dev/sites/christianerben-eu`. Keep the workflow conservative: update everything only when updates exist, verify locally and visually, then promote through the configured branch chain with Vercel checks at each stage.
+Use this skill to perform a full dependency release for `/dev/sites/christianerben-eu`. Keep the workflow conservative: update everything only when updates exist, verify locally and visually, then promote through the configured branch chain with Vercel checks at each stage. A request to execute this skill fully authorizes the complete repository workflow described here; do not stop after the package update or PR creation.
 
-Read `references/repo-workflow.md` before starting. Use the bundled scripts from this skill for page discovery, screenshot capture, and tolerant visual comparison.
+Read `references/repo-workflow.md` before starting. Use the bundled Playwright Test workflow for page discovery, stable baseline snapshots, and tolerant visual comparison. When the invocation names `$git-code-review-autopilot` or `$internal-pages-upload`, read and follow those installed skills at their handoff points; their current instructions remain authoritative.
 
 ## Preflight
 
@@ -19,11 +19,17 @@ Read `references/repo-workflow.md` before starting. Use the bundled scripts from
 
 ## Local Update Flow
 
-1. Start the app with `bun run dev:local` on port 3000 (`bun run dev` would additionally expose the server over the Tailnet, which a release run does not need).
-2. Capture baseline screenshots:
+1. Ensure the exact local Playwright dependency and Chromium are available:
 
 ```bash
-bun .codex/skills/christianerben-dependency-release/scripts/capture-pages.mjs --base-url http://localhost:3000 --phase before
+bun install --frozen-lockfile
+bunx --no-install playwright install chromium
+```
+
+2. Store stable baseline snapshots. Playwright starts and stops a fresh local Next.js server for this phase:
+
+```bash
+bun run visual:baseline --artifact-dir .artifacts/dependency-update-release/<run-id>
 ```
 
 3. Update all dependencies and devDependencies to `latest` with Bun, including major versions. Update both `package.json` and `bun.lock`.
@@ -36,20 +42,14 @@ bun run check
 This is the full quality gate (lint, typecheck, tests, async leak detection, generated artifact verification, production build). Screenshot capture and comparison remain a separate, additional visual gate; `bun run check` does not replace them.
 
 5. Fix failures autonomously when they are caused by the update. Keep fixes scoped.
-6. Restart the local dev server after build-affecting fixes.
-7. Capture after screenshots:
+6. Compare the updated site with the stored baseline. Playwright starts another fresh local Next.js server:
 
 ```bash
-bun .codex/skills/christianerben-dependency-release/scripts/capture-pages.mjs --base-url http://localhost:3000 --phase after --run-id <run-id>
+bun run visual:compare --artifact-dir .artifacts/dependency-update-release/<run-id>
 ```
 
-8. Compare screenshots tolerantly:
-
-```bash
-bun .codex/skills/christianerben-dependency-release/scripts/compare-screenshots.mjs --run-id <run-id>
-```
-
-Treat blank pages, Next error pages, severe layout collapse, unexpected browser console errors, and HTTP failures as blockers. Do not require pixel-perfect equality.
+7. The visual commands use the exact pinned `@playwright/test` version, four workers, desktop/mobile projects, full-page screenshots, font and visible-image waits, reduced motion, disabled animations, fixed locale/timezone/device scale, and two consecutive stable screenshots. They reject missing baselines and route-set drift before starting Playwright.
+8. Treat blank pages, Next error pages, severe layout collapse, unexpected browser console errors, request failures, HTTP failures, or a visual delta above the configured tolerance as blockers. Do not require pixel-perfect equality. Playwright retains its JSON report, traces, actual images, and diffs under the run artifact directory when applicable.
 
 ## Relevant Update Follow-Up
 
@@ -78,7 +78,7 @@ bun run update:last-updated
 
 2. When generated files change, re-run `bun run check` and the screenshot comparison.
 3. Push the branch and open a PR against `development`.
-4. Use the skill `git-code-review-autopilot` to check on the pr
+4. Hand the PR to `$git-code-review-autopilot`. That skill owns the complete current-head GitHub check, Codex review, thread-response, repeat-after-push, and merge gate. Do not merge before it returns a successful review outcome.
 5. Merge locally into updated `development`, then run `.githooks/pre-commit` on the real `development` branch. Include any generated files in the merge commit.
 6. Push `development`, wait for Vercel deployment `READY`, and fetch logs/fix/retry on `ERROR` or `CANCELED`.
 7. Merge and push `development -> preproduction`, wait for Vercel `READY`.
@@ -89,7 +89,7 @@ bun run update:last-updated
    - delete the local and remote `codex/update-dependencies-<timestamp>` branch after it has been merged
    - remove any temporary local worktree or checkout created only for the update run
    - keep `.artifacts/` uncommitted and leave the worktree clean unless the user explicitly asks to keep artifacts or branches
-10. Write a final self-contained HTML status page under `.artifacts/dependency-update-release/<run-id>/status.html`. Keep this report and every supporting artifact uncommitted. Include:
+10. Write the structured Git update status JSON required by `$internal-pages-upload`, then use that skill's canonical dark Gantt renderer to create `.artifacts/dependency-update-release/<run-id>/status.html`. Keep the report and every supporting artifact uncommitted. Include:
     - run id, job/status/session/cwd/finished timestamp when available
     - one-sentence completion outcome
     - what was changed and what steps were performed
@@ -103,13 +103,14 @@ bun run update:last-updated
     - GitHub review/check watch outcome and any residual notes
     - local artifact paths as text, not embedded local images
     - escaped dynamic text before inserting it into HTML
-11. Publish the final HTML status page by using the `internal-pages-upload` skill with `.artifacts/dependency-update-release/<run-id>/status.html`. Do not duplicate upload implementation details here; read and follow the installed `internal-pages-upload` skill at publish time so changes to that skill remain authoritative.
-12. Finish with a concise final response that includes the uploaded internal status page URL first, then the local `.artifacts/.../status.html` path and any upload failure note if publishing did not complete.
+11. Publish and verify the final HTML status page by handing it to `$internal-pages-upload` with the required 14-day TTL. Do not duplicate upload implementation details here; the installed upload skill remains authoritative.
+12. Finish with the returned internal report URL first. Then list every available tracking or follow-up issue URL, PR URL, and deployment URL for `development`, `preproduction`, and `main`, followed by the local `.artifacts/.../status.html` path. Explicitly say when a link category has no available link. Include any upload failure note if publishing did not complete.
 
 ## Useful Scripts
 
-- `scripts/discover-pages.mjs`: lists real Pages Router routes, excluding API routes and special Next files.
-- `scripts/capture-pages.mjs`: captures desktop and mobile screenshots under `.artifacts/dependency-update-release/<run-id>/<phase>/`.
-- `scripts/compare-screenshots.mjs`: compares `before` and `after` screenshots with tolerant thresholds and writes `comparison-report.json`.
+- `scripts/run-visual-check.mjs`: validates inputs and route coverage, then runs the pinned local Playwright Test workflow.
+- `scripts/playwright.visual.config.ts`: configures managed Next.js servers, deterministic desktop/mobile projects, stable comparison thresholds, and failure artifacts.
+- `scripts/visual-snapshots.pw.ts`: verifies page health and full-page snapshots for every release route.
+- `scripts/discover-pages.mjs`: lists real Pages Router routes or the explicit release route set.
 
 All generated artifacts must remain under `.artifacts/` and must not be committed.

--- a/.codex/skills/christianerben-dependency-release/SKILL.md
+++ b/.codex/skills/christianerben-dependency-release/SKILL.md
@@ -42,14 +42,20 @@ bun run check
 This is the full quality gate (lint, typecheck, tests, async leak detection, generated artifact verification, production build). Screenshot capture and comparison remain a separate, additional visual gate; `bun run check` does not replace them.
 
 5. Fix failures autonomously when they are caused by the update. Keep fixes scoped.
-6. Compare the updated site with the stored baseline. Playwright starts another fresh local Next.js server:
+6. Install Chromium again after the dependency update so its browser revision matches the updated Playwright package:
+
+```bash
+bunx --no-install playwright install chromium
+```
+
+7. Compare the updated site with the stored baseline. Playwright starts another fresh local Next.js server:
 
 ```bash
 bun run visual:compare --artifact-dir .artifacts/dependency-update-release/<run-id>
 ```
 
-7. The visual commands use the exact pinned `@playwright/test` version, four workers, desktop/mobile projects, full-page screenshots, font and visible-image waits, reduced motion, disabled animations, fixed locale/timezone/device scale, and two consecutive stable screenshots. They reject missing baselines and route-set drift before starting Playwright.
-8. Treat blank pages, Next error pages, severe layout collapse, unexpected browser console errors, request failures, HTTP failures, or a visual delta above the configured tolerance as blockers. Do not require pixel-perfect equality. Playwright retains its JSON report, traces, actual images, and diffs under the run artifact directory when applicable.
+8. The visual commands use the exact pinned `@playwright/test` version, four workers, desktop/mobile projects, full-page screenshots, font and lazy-image waits, reduced motion, disabled animations, fixed locale/timezone/device scale, and two consecutive stable screenshots. They reject missing baselines and route-set drift before starting Playwright.
+9. Treat blank pages, Next error pages, severe layout collapse, unexpected browser console errors, request failures, HTTP failures, or a visual delta above the configured tolerance as blockers. Do not require pixel-perfect equality. Playwright retains its JSON report, traces, actual images, and diffs under the run artifact directory when applicable.
 
 ## Relevant Update Follow-Up
 

--- a/.codex/skills/christianerben-dependency-release/agents/openai.yaml
+++ b/.codex/skills/christianerben-dependency-release/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Christian Erben Dependency Release"
   short_description: "Upgrade dependencies and release safely"
-  default_prompt: "Use $christianerben-dependency-release to update all dependencies, verify screenshots, open the PR, merge, and check Vercel deployments."
+  default_prompt: "Führe $christianerben-dependency-release vollständig aus. Nutze für den darin vorgesehenen GitHub-Handoff $git-code-review-autopilot und veröffentliche den abschließenden HTML-Bericht mit $internal-pages-upload. Gib am Ende die zurückgegebene Report-URL und alle verfügbaren Issue-, PR- und Deployment-Links aus."

--- a/.codex/skills/christianerben-dependency-release/references/repo-workflow.md
+++ b/.codex/skills/christianerben-dependency-release/references/repo-workflow.md
@@ -25,7 +25,7 @@ Run these generator commands explicitly on the PR branch before final verificati
 
 ## Visual Verification
 
-Use the pinned local Playwright Test workflow to capture stable full-page desktop and mobile snapshots for `/`, `/cv`, `/imprint`, `/privacy`, `/sitemap`, and `/404`. Each phase owns a fresh local Next.js server. The workflow waits for fonts and visible images, fixes locale/timezone/device scale, reduces motion, disables animations, and runs four workers in parallel. Its route manifest must match between phases. The comparison is tolerant: expect small rendering differences after dependency upgrades, but fail for blank pages, error pages, severe layout breaks, missing routes, failed network responses, unexpected console errors, or excessive visual deltas.
+Use the pinned local Playwright Test workflow to capture stable full-page desktop and mobile snapshots for `/`, `/cv`, `/imprint`, `/privacy`, `/sitemap`, and `/404`. Each phase owns a fresh local Next.js server. Install Chromium both before the baseline and again after dependency updates so its revision matches the active Playwright package. The workflow waits for fonts, scrolls through each page to trigger every lazy image, awaits image decoding, fixes locale/timezone/device scale, reduces motion, disables animations, and runs four workers in parallel. Its route manifest must match between phases. The comparison is tolerant: expect small rendering differences after dependency upgrades, but fail for blank pages, error pages, severe layout breaks, missing routes, failed network responses, unexpected console errors, or excessive visual deltas.
 
 ## Relevant Update Follow-Up
 

--- a/.codex/skills/christianerben-dependency-release/references/repo-workflow.md
+++ b/.codex/skills/christianerben-dependency-release/references/repo-workflow.md
@@ -8,7 +8,7 @@
 - Vercel team: `Christian's projects` / `christians-projects-693c521b`
 - Vercel project: `christianerben-eu` / `prj_0P9YPvnH3AoHjgps5Sady3gnc3IW`
 - Screenshot pages: `/`, `/cv`, `/imprint`, `/privacy`, `/sitemap`, `/404`
-- Commands: `bun run dev` (Tailnet dev flow), `bun run dev:local` (plain local `next dev`), `bun run check` (full quality gate: lint, typecheck, tests, async leak detection, generated artifact verification, production build)
+- Commands: `bun run visual:baseline --artifact-dir <run-dir>`, `bun run visual:compare --artifact-dir <run-dir>`, `bun run check` (full quality gate: lint, typecheck, tests, async leak detection, generated artifact verification, production build)
 
 ## Hook And Generated Files
 
@@ -25,7 +25,7 @@ Run these generator commands explicitly on the PR branch before final verificati
 
 ## Visual Verification
 
-Capture desktop and mobile screenshots for `/`, `/cv`, `/imprint`, `/privacy`, `/sitemap`, and `/404`. The comparison is tolerant: expect small rendering differences after dependency upgrades, but fail for blank pages, error pages, severe layout breaks, missing routes, failed network responses, or unexpected console errors.
+Use the pinned local Playwright Test workflow to capture stable full-page desktop and mobile snapshots for `/`, `/cv`, `/imprint`, `/privacy`, `/sitemap`, and `/404`. Each phase owns a fresh local Next.js server. The workflow waits for fonts and visible images, fixes locale/timezone/device scale, reduces motion, disables animations, and runs four workers in parallel. Its route manifest must match between phases. The comparison is tolerant: expect small rendering differences after dependency upgrades, but fail for blank pages, error pages, severe layout breaks, missing routes, failed network responses, unexpected console errors, or excessive visual deltas.
 
 ## Relevant Update Follow-Up
 
@@ -63,7 +63,7 @@ After `development`, `preproduction`, and `main` have been pushed and the final 
 
 ## Final Status Report
 
-Generate a self-contained HTML status page at `.artifacts/dependency-update-release/<run-id>/status.html`. Keep the report and every supporting artifact under `.artifacts/`, and do not commit them.
+Generate the structured Git update status JSON required by `internal-pages-upload`, then render its canonical dark Gantt page at `.artifacts/dependency-update-release/<run-id>/status.html`. Keep the report and every supporting artifact under `.artifacts/`, and do not commit them.
 
 Include the most useful operational facts:
 
@@ -79,6 +79,6 @@ Include the most useful operational facts:
 - Vercel deployment results for `development`, `preproduction`, and `main`
 - GitHub review/check watch outcome and any residual notes
 
-Publish the HTML status page by using the `internal-pages-upload` skill with `.artifacts/dependency-update-release/<run-id>/status.html`. Read and follow the installed `internal-pages-upload` skill at publish time; do not copy its upload commands into this workflow.
+Publish and verify the HTML status page with a 14-day TTL by using `$internal-pages-upload` with `.artifacts/dependency-update-release/<run-id>/status.html`. Read and follow the installed skill at publish time; do not copy its upload commands into this workflow. Return the exact upload response URL first, then every available issue, PR, and branch deployment URL.
 
 Return the uploaded internal status page URL in the final user response so the report can be checked externally. If publishing fails, report the exact upload failure and still provide the local `.artifacts/.../status.html` path.

--- a/.codex/skills/christianerben-dependency-release/scripts/discover-pages.mjs
+++ b/.codex/skills/christianerben-dependency-release/scripts/discover-pages.mjs
@@ -2,8 +2,6 @@
 import { readdirSync, statSync } from "node:fs";
 import { join, relative, sep } from "node:path";
 
-const repoRoot = process.cwd();
-const pagesDir = join(repoRoot, "src", "pages");
 const explicitRoutes = ["/", "/cv", "/imprint", "/privacy", "/sitemap", "/404"];
 const excludedNames = new Set(["_app", "_document", "_error"]);
 const pageExtensions = new Set([".js", ".jsx", ".ts", ".tsx", ".md", ".mdx"]);
@@ -23,7 +21,7 @@ function extensionOf(filePath) {
   return "";
 }
 
-function routeFromFile(filePath) {
+function routeFromFile(filePath, pagesDir) {
   const ext = extensionOf(filePath);
   if (!ext) return null;
 
@@ -39,16 +37,16 @@ function routeFromFile(filePath) {
   return route === "" ? "/" : route;
 }
 
-function walk(dir) {
+function walk(dir, pagesDir) {
   const routes = [];
   for (const entry of readdirSync(dir)) {
     const filePath = join(dir, entry);
     const stats = statSync(filePath);
     if (stats.isDirectory()) {
-      if (entry !== "api") routes.push(...walk(filePath));
+      if (entry !== "api") routes.push(...walk(filePath, pagesDir));
       continue;
     }
-    const route = routeFromFile(filePath);
+    const route = routeFromFile(filePath, pagesDir);
     if (route) routes.push(route);
   }
   return routes;
@@ -62,11 +60,18 @@ function uniqueSorted(routes) {
   });
 }
 
-const options = parseArgs();
-const routes = options.explicit ? explicitRoutes : uniqueSorted(walk(pagesDir));
+export function discoverPages(repoRoot = process.cwd(), explicit = false) {
+  if (explicit) return [...explicitRoutes];
+  const pagesDir = join(repoRoot, "src", "pages");
+  return uniqueSorted(walk(pagesDir, pagesDir));
+}
 
-if (options.json) {
-  console.log(JSON.stringify(routes, null, 2));
-} else {
-  console.log(routes.join("\n"));
+if (import.meta.main) {
+  const options = parseArgs();
+  const routes = discoverPages(process.cwd(), options.explicit);
+  if (options.json) {
+    console.log(JSON.stringify(routes, null, 2));
+  } else {
+    console.log(routes.join("\n"));
+  }
 }

--- a/.codex/skills/christianerben-dependency-release/scripts/playwright.visual.config.ts
+++ b/.codex/skills/christianerben-dependency-release/scripts/playwright.visual.config.ts
@@ -1,0 +1,66 @@
+import path from "node:path";
+
+import { defineConfig } from "@playwright/test";
+
+const repoRoot = process.env.VISUAL_REPO_ROOT;
+const baselineDir = process.env.VISUAL_BASELINE_DIR;
+const resultsDir = process.env.VISUAL_RESULTS_DIR;
+const baseURL = process.env.VISUAL_BASE_URL ?? "http://127.0.0.1:4321";
+const workers = Number(process.env.VISUAL_WORKERS ?? "4");
+
+if (!repoRoot || !baselineDir || !resultsDir) {
+  throw new Error("Run visual checks through run-visual-check.mjs so artifact paths are configured.");
+}
+if (!Number.isInteger(workers) || workers < 1) {
+  throw new Error("VISUAL_WORKERS must be a positive integer.");
+}
+
+export default defineConfig({
+  testDir: path.dirname(import.meta.filename),
+  testMatch: "visual-snapshots.pw.ts",
+  outputDir: resultsDir,
+  snapshotPathTemplate: path.join(baselineDir, "{arg}-{projectName}{ext}"),
+  fullyParallel: true,
+  workers,
+  retries: 0,
+  reporter: [
+    ["line"],
+    ["json", { outputFile: path.join(resultsDir, "playwright-report.json") }],
+  ],
+  timeout: 45_000,
+  expect: {
+    toHaveScreenshot: {
+      animations: "disabled",
+      maxDiffPixelRatio: 0.08,
+      threshold: 0.1,
+      timeout: 15_000,
+    },
+  },
+  use: {
+    baseURL,
+    colorScheme: "light",
+    deviceScaleFactor: 1,
+    locale: "de-DE",
+    reducedMotion: "reduce",
+    timezoneId: "Europe/Berlin",
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: "bun run dev:local -- --hostname 127.0.0.1 --port 4321",
+    cwd: repoRoot,
+    env: process.env,
+    reuseExistingServer: false,
+    timeout: 120_000,
+    url: baseURL,
+  },
+  projects: [
+    {
+      name: "desktop",
+      use: { viewport: { width: 1440, height: 1200 } },
+    },
+    {
+      name: "mobile",
+      use: { viewport: { width: 390, height: 1000 } },
+    },
+  ],
+});

--- a/.codex/skills/christianerben-dependency-release/scripts/run-visual-check.mjs
+++ b/.codex/skills/christianerben-dependency-release/scripts/run-visual-check.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env bun
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+import { discoverPages } from "./discover-pages.mjs";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+export const repoRoot = resolve(scriptDir, "../../../..");
+export const configPath = join(scriptDir, "playwright.visual.config.ts");
+const manifestName = "visual-routes.json";
+
+export function buildCommand(mode) {
+  const command = [
+    "bunx",
+    "--no-install",
+    "playwright",
+    "test",
+    "--config",
+    configPath,
+  ];
+  if (mode === "baseline") command.push("--update-snapshots=all");
+  return command;
+}
+
+export function buildEnvironment(artifactDir, workers, root = repoRoot) {
+  const resolvedArtifacts = resolve(artifactDir);
+  return {
+    ...process.env,
+    VISUAL_REPO_ROOT: resolve(root),
+    VISUAL_BASELINE_DIR: join(resolvedArtifacts, "before"),
+    VISUAL_RESULTS_DIR: join(resolvedArtifacts, "results"),
+    VISUAL_BASE_URL: "http://127.0.0.1:4321",
+    VISUAL_WORKERS: String(workers),
+  };
+}
+
+export function writeRouteManifest(artifactDir, routes) {
+  const manifestPath = join(resolve(artifactDir), manifestName);
+  mkdirSync(dirname(manifestPath), { recursive: true });
+  writeFileSync(manifestPath, `${JSON.stringify({ routes }, null, 2)}\n`);
+  return manifestPath;
+}
+
+export function readRouteManifest(artifactDir) {
+  const manifestPath = join(resolve(artifactDir), manifestName);
+  if (!existsSync(manifestPath)) {
+    throw new Error(`invalid or missing route manifest: ${manifestPath}`);
+  }
+  let payload;
+  try {
+    payload = JSON.parse(readFileSync(manifestPath, "utf8"));
+  } catch {
+    throw new Error(`invalid or missing route manifest: ${manifestPath}`);
+  }
+  if (
+    !payload ||
+    !Array.isArray(payload.routes) ||
+    !payload.routes.every((route) => typeof route === "string")
+  ) {
+    throw new Error(`invalid route manifest: ${manifestPath}`);
+  }
+  return payload.routes;
+}
+
+export function parseArgs(args) {
+  const [mode, ...rest] = args;
+  if (!["baseline", "compare"].includes(mode)) {
+    throw new Error("Usage: run-visual-check.mjs baseline|compare --artifact-dir <path> [--workers 4]");
+  }
+  let artifactDir = "";
+  let workers = 4;
+  for (let index = 0; index < rest.length; index += 1) {
+    if (rest[index] === "--artifact-dir") artifactDir = rest[++index] ?? "";
+    else if (rest[index] === "--workers") workers = Number(rest[++index]);
+    else throw new Error(`Unknown argument: ${rest[index]}`);
+  }
+  if (!artifactDir) throw new Error("--artifact-dir is required");
+  if (!Number.isInteger(workers) || workers < 1) {
+    throw new Error("--workers must be a positive integer");
+  }
+  return { mode, artifactDir, workers };
+}
+
+export function validateComparison(artifactDir, currentRoutes) {
+  const baselineDir = join(resolve(artifactDir), "before");
+  if (
+    !existsSync(baselineDir) ||
+    !readdirSync(baselineDir).some((fileName) => fileName.endsWith(".png"))
+  ) {
+    throw new Error(`no baseline screenshots found in ${baselineDir}`);
+  }
+  const baselineRoutes = readRouteManifest(artifactDir);
+  const removed = baselineRoutes.filter((route) => !currentRoutes.includes(route)).sort();
+  const added = currentRoutes.filter((route) => !baselineRoutes.includes(route)).sort();
+  if (removed.length || added.length) {
+    throw new Error(
+      `visual route set changed since baseline: removed=${JSON.stringify(removed)}, added=${JSON.stringify(added)}`,
+    );
+  }
+}
+
+export function main(args = process.argv.slice(2)) {
+  const options = parseArgs(args);
+  const routes = discoverPages(repoRoot, true);
+  if (options.mode === "compare") validateComparison(options.artifactDir, routes);
+
+  const [command, ...commandArgs] = buildCommand(options.mode);
+  const result = spawnSync(command, commandArgs, {
+    cwd: repoRoot,
+    env: buildEnvironment(options.artifactDir, options.workers),
+    stdio: "inherit",
+  });
+  if (result.error) throw result.error;
+  if (result.status === 0) {
+    if (options.mode === "baseline") writeRouteManifest(options.artifactDir, routes);
+    const action = options.mode === "baseline" ? "stored" : "matched";
+    console.log(`Visual screenshots ${action}: ${join(resolve(options.artifactDir), "before")}`);
+  }
+  return result.status ?? 1;
+}
+
+if (import.meta.main) process.exitCode = main();

--- a/.codex/skills/christianerben-dependency-release/scripts/run-visual-check.test.ts
+++ b/.codex/skills/christianerben-dependency-release/scripts/run-visual-check.test.ts
@@ -1,0 +1,97 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  buildCommand,
+  buildEnvironment,
+  parseArgs,
+  readRouteManifest,
+  validateComparison,
+  writeRouteManifest,
+} from "./run-visual-check.mjs";
+
+const temporaryDirectories: string[] = [];
+
+function makeTemporaryDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "dependency-visual-check-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("dependency release visual runner", () => {
+  it("uses the pinned local Playwright CLI and update mode for baselines", () => {
+    expect(buildCommand("baseline").slice(0, 4)).toEqual([
+      "bunx",
+      "--no-install",
+      "playwright",
+      "test",
+    ]);
+    expect(buildCommand("baseline")).toContain("--update-snapshots=all");
+    expect(buildCommand("compare")).not.toContain("--update-snapshots=all");
+  });
+
+  it("configures isolated baseline and result directories", () => {
+    const artifactDir = makeTemporaryDirectory();
+    const environment = buildEnvironment(artifactDir, 3, "/tmp/repo");
+    expect(environment.VISUAL_BASELINE_DIR).toBe(join(artifactDir, "before"));
+    expect(environment.VISUAL_RESULTS_DIR).toBe(join(artifactDir, "results"));
+    expect(environment.VISUAL_WORKERS).toBe("3");
+  });
+
+  it("writes and reads the exact route manifest", () => {
+    const artifactDir = makeTemporaryDirectory();
+    const manifestPath = writeRouteManifest(artifactDir, ["/", "/cv"]);
+    expect(existsSync(manifestPath)).toBe(true);
+    expect(JSON.parse(readFileSync(manifestPath, "utf8")).routes).toEqual(["/", "/cv"]);
+    expect(readRouteManifest(artifactDir)).toEqual(["/", "/cv"]);
+  });
+
+  it("rejects comparison without a baseline", () => {
+    const artifactDir = makeTemporaryDirectory();
+    expect(() => validateComparison(artifactDir, ["/"])).toThrow(
+      "no baseline screenshots found",
+    );
+    mkdirSync(join(artifactDir, "before"));
+    writeRouteManifest(artifactDir, ["/"]);
+    expect(() => validateComparison(artifactDir, ["/"])).toThrow(
+      "no baseline screenshots found",
+    );
+  });
+
+  it("rejects route-set drift before Playwright starts", () => {
+    const artifactDir = makeTemporaryDirectory();
+    writeRouteManifest(artifactDir, ["/", "/removed"]);
+    mkdirSync(join(artifactDir, "before"));
+    writeFileSync(join(artifactDir, "before", "home-desktop.png"), "png");
+    expect(() => validateComparison(artifactDir, ["/", "/added"])).toThrow(
+      'removed=["/removed"], added=["/added"]',
+    );
+  });
+
+  it("validates required arguments and worker count", () => {
+    expect(parseArgs(["baseline", "--artifact-dir", "/tmp/run", "--workers", "2"])).toEqual({
+      mode: "baseline",
+      artifactDir: "/tmp/run",
+      workers: 2,
+    });
+    expect(() => parseArgs(["compare", "--artifact-dir", "/tmp/run", "--workers", "0"])).toThrow(
+      "--workers must be a positive integer",
+    );
+  });
+});

--- a/.codex/skills/christianerben-dependency-release/scripts/visual-snapshots.pw.ts
+++ b/.codex/skills/christianerben-dependency-release/scripts/visual-snapshots.pw.ts
@@ -16,6 +16,9 @@ for (const route of routes) {
   test(`visual ${route}`, async ({ page }) => {
     const consoleErrors: string[] = [];
     const failedRequests: string[] = [];
+    await page.addInitScript(() => {
+      window.setInterval = (() => 0) as typeof window.setInterval;
+    });
     page.on("console", (message) => {
       if (message.type() === "error") consoleErrors.push(message.text());
     });
@@ -32,16 +35,21 @@ for (const route of routes) {
 
     await page.evaluate(async () => {
       await document.fonts?.ready;
-      const visibleImages = [...document.images].filter((image) => {
-        const rect = image.getBoundingClientRect();
-        return (
-          rect.bottom > 0 &&
-          rect.right > 0 &&
-          rect.top < window.innerHeight &&
-          rect.left < window.innerWidth
-        );
-      });
-      await Promise.all(visibleImages.map((image) => image.decode().catch(() => undefined)));
+      const viewportStep = Math.max(window.innerHeight, 1);
+      for (
+        let offset = 0;
+        offset < document.documentElement.scrollHeight;
+        offset += viewportStep
+      ) {
+        window.scrollTo(0, offset);
+        await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+      }
+      window.scrollTo(0, document.documentElement.scrollHeight);
+      await Promise.all(
+        [...document.images].map((image) => image.decode().catch(() => undefined)),
+      );
+      window.scrollTo(0, 0);
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
     });
 
     const expectedNotFound = route === "/404" && status === 404;

--- a/.codex/skills/christianerben-dependency-release/scripts/visual-snapshots.pw.ts
+++ b/.codex/skills/christianerben-dependency-release/scripts/visual-snapshots.pw.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "@playwright/test";
+
+import { discoverPages } from "./discover-pages.mjs";
+
+const repoRoot = process.env.VISUAL_REPO_ROOT;
+if (!repoRoot) throw new Error("VISUAL_REPO_ROOT is required.");
+
+const routes = discoverPages(repoRoot, true);
+
+function screenshotName(route: string): string {
+  const normalized = route.replace(/^\/+|\/+$/g, "") || "home";
+  return `${normalized.replace(/[^a-zA-Z0-9]+/g, "-")}.png`;
+}
+
+for (const route of routes) {
+  test(`visual ${route}`, async ({ page }) => {
+    const consoleErrors: string[] = [];
+    const failedRequests: string[] = [];
+    page.on("console", (message) => {
+      if (message.type() === "error") consoleErrors.push(message.text());
+    });
+    page.on("requestfailed", (request) => {
+      failedRequests.push(
+        `${request.method()} ${request.url()} ${request.failure()?.errorText ?? ""}`.trim(),
+      );
+    });
+
+    const response = await page.goto(route, { waitUntil: "load" });
+    const status = response?.status() ?? 0;
+    const title = await page.title();
+    const bodyText = await page.locator("body").innerText();
+
+    await page.evaluate(async () => {
+      await document.fonts?.ready;
+      const visibleImages = [...document.images].filter((image) => {
+        const rect = image.getBoundingClientRect();
+        return (
+          rect.bottom > 0 &&
+          rect.right > 0 &&
+          rect.top < window.innerHeight &&
+          rect.left < window.innerWidth
+        );
+      });
+      await Promise.all(visibleImages.map((image) => image.decode().catch(() => undefined)));
+    });
+
+    const expectedNotFound = route === "/404" && status === 404;
+    expect(
+      (status >= 200 && status < 400) || expectedNotFound,
+      `${route}: unexpected HTTP ${status}`,
+    ).toBe(true);
+    expect(bodyText.trim().length, `${route}: page appears blank`).toBeGreaterThanOrEqual(40);
+    if (route !== "/404") {
+      expect(title, `${route}: error-like page title`).not.toMatch(
+        /404|500|application error|internal server error/i,
+      );
+    }
+
+    await expect(page).toHaveScreenshot(screenshotName(route), {
+      animations: "disabled",
+      fullPage: true,
+    });
+
+    const unexpectedConsoleErrors = consoleErrors.filter(
+      (message) =>
+        !(
+          route === "/404" &&
+          (/Failed to load resource: the server responded with a status of 404/.test(message) ||
+            /404 Error: User attempted to access non-existent route: \/404/.test(message))
+        ),
+    );
+    const unexpectedRequestFailures = failedRequests.filter(
+      (failure) =>
+        !(
+          route === "/cv" &&
+          /^GET .*\/cv\/christian_erben_cv_(en|de)(?:_with_certificates)?\.pdf net::ERR_ABORTED$/.test(
+            failure,
+          )
+        ),
+    );
+    expect(unexpectedConsoleErrors, `${route}: unexpected console errors`).toEqual([]);
+    expect(unexpectedRequestFailures, `${route}: unexpected request failures`).toEqual([]);
+  });
+}

--- a/bun.lock
+++ b/bun.lock
@@ -36,6 +36,7 @@
         "zod": "4.4.3",
       },
       "devDependencies": {
+        "@playwright/test": "1.62.0",
         "@tailwindcss/postcss": "4.3.3",
         "@tailwindcss/typography": "0.5.20",
         "@testing-library/dom": "10.4.1",
@@ -208,6 +209,8 @@
     "@pdf-lib/standard-fonts": ["@pdf-lib/standard-fonts@1.0.0", "", { "dependencies": { "pako": "^1.0.6" } }, "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA=="],
 
     "@pdf-lib/upng": ["@pdf-lib/upng@1.0.1", "", { "dependencies": { "pako": "^1.0.10" } }, "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ=="],
+
+    "@playwright/test": ["@playwright/test@1.62.0", "", { "dependencies": { "playwright": "1.62.0" }, "bin": { "playwright": "cli.js" } }, "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA=="],
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.7", "", {}, "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q=="],
 
@@ -495,7 +498,7 @@
 
     "fontkit": ["fontkit@2.0.4", "", { "dependencies": { "@swc/helpers": "^0.5.12", "brotli": "^1.3.2", "clone": "^2.1.2", "dfa": "^1.2.0", "fast-deep-equal": "^3.1.3", "restructure": "^3.0.0", "tiny-inflate": "^1.0.3", "unicode-properties": "^1.4.0", "unicode-trie": "^2.0.0" } }, "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
 
@@ -598,6 +601,10 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "playwright": ["playwright@1.62.0", "", { "dependencies": { "playwright-core": "1.62.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw=="],
+
+    "playwright-core": ["playwright-core@1.62.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA=="],
 
     "png-js": ["png-js@2.0.0", "", { "dependencies": { "fflate": "^0.8.2" } }, "sha512-GdzJuUMc6ZSpxFJWVxtOH1bzYHym+TOnveqUjb+VJIbZWbZzyiRGFiKhbiielfpYbgMlhHVhsJ0FTazfuRFkMA=="],
 
@@ -788,6 +795,8 @@
     "use-callback-ref/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "use-sidecar/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "@rolldown/binding-wasm32-wasi/@emnapi/runtime/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "test:run": "vitest --run",
     "test:leaks": "bash -o pipefail -c 'vitest --run --detect-async-leaks 2>&1 | tee /tmp/vitest-async-leaks.log && ! grep -Eq \"(Async Leaks [1-9]|Leaks [1-9][0-9]* leaks)\" /tmp/vitest-async-leaks.log'",
     "check": "bun run lint && bun run typecheck && bun run test:run && bun run test:leaks && bun run verify:generated && bun run build",
+    "visual:baseline": "bun .codex/skills/christianerben-dependency-release/scripts/run-visual-check.mjs baseline",
+    "visual:compare": "bun .codex/skills/christianerben-dependency-release/scripts/run-visual-check.mjs compare",
     "generate:cv": "bun scripts/generate-cv.tsx",
     "generate:sitemap": "bun scripts/generate-sitemap.cjs",
     "generate:llms": "bun scripts/generate-llms.ts",
@@ -62,6 +64,7 @@
     "postcss": "8.5.23"
   },
   "devDependencies": {
+    "@playwright/test": "1.62.0",
     "@tailwindcss/postcss": "4.3.3",
     "@tailwindcss/typography": "0.5.20",
     "@testing-library/dom": "10.4.1",


### PR DESCRIPTION
## Summary

- port the deterministic Playwright Test visual workflow from keeperxy/wow-vi6-org#40 while preserving portfolio-specific page-health guards
- pin `@playwright/test` 1.62.0, manage fresh Next.js servers, validate route manifests, run stable full-page desktop/mobile snapshots, and retain Playwright reports and traces
- update `$christianerben-dependency-release` to hand GitHub review to `$git-code-review-autopilot`, render and publish through `$internal-pages-upload`, and return all available workflow links
- set the requested concise German automation prompt as the skill default

## Performance result

The workflow is more deterministic and self-contained, but it is **not faster in this repository**:

| Workflow | Runs | Median |
| --- | --- | ---: |
| Existing custom capture/compare | 44.29 s, 34.47 s, 36.10 s | 36.10 s |
| Managed Playwright Test, 4 workers | 37.75 s, 37.89 s, 39.22 s | 37.89 s |

That is a 4.96% median slowdown. Two workers took 42.73 s and six workers 39.15 s. Four workers remain the best tested setting. The old workflow was measured with an already-running server; the new measurements include two fresh managed server lifecycles.

## Verification

- targeted runner tests: 6 passed
- unchanged visual baseline/comparison cycles: 12 desktop/mobile cases per phase passed
- `bun run check`: lint, typecheck, 101 tests, async leak detection, generated artifact verification, and production build passed

Closes #141