### PR TITLE
Pass Lighthouse Agentic Browsing audits

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,7 +1,7 @@
 # llms.txt for christianerben.eu
 # This file provides structured information for AI language models.
 # For more information, see https://llmstxt.org/
-# Version 1.0, Generated on 2026-08-01
+# Version 1.0, Generated on 2026-08-07
 
 # --- PERMISSIONS ---
 User-Agent: *
@@ -21,8 +21,8 @@ Sitemap: https://christianerben.eu/sitemap.xml
 [de] Christian Erben
 
 [Published]:
-[en] 2026-08-01
-[de] 01.08.2026
+[en] 2026-08-07
+[de] 07.08.2026
 
 [Languages]:
 [en] English, German
@@ -75,6 +75,14 @@ Sitemap: https://christianerben.eu/sitemap.xml
 [Contact]:
 [en] Contact information is available via the contact form on the main page or via email to christian.erben@degit.de.
 [de] Kontaktinformationen sind über das Kontaktformular auf der Startseite oder per E-Mail an christian.erben@degit.de verfügbar.
+
+
+## Key Links / Wichtige Links
+- [Homepage](https://christianerben.eu/): Main sections including About, Experience, Projects, Skills, and Contact / Hauptbereiche einschließlich Über Mich, Erfahrung, Projekte, Fähigkeiten und Kontakt.
+- [CV](https://christianerben.eu/cv): Interactive CV and downloads / Interaktiver Lebenslauf und Downloads.
+- [Imprint](https://christianerben.eu/imprint): Legal notice / Impressum.
+- [Privacy](https://christianerben.eu/privacy): Privacy policy / Datenschutzerklärung.
+- [Sitemap](https://christianerben.eu/sitemap): Human-readable sitemap / Für Menschen lesbare Sitemap.
 
 # --- SECURITY & COMPLIANCE / GOVERNANCE ---
 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,7 +3,7 @@
 
   <url>
     <loc>https://christianerben.eu/</loc>
-    <lastmod>2026-07-03</lastmod>
+    <lastmod>2026-08-07</lastmod>
     <priority>1</priority>
   </url>
 
@@ -33,7 +33,7 @@
 
   <url>
     <loc>https://christianerben.eu/llms.txt</loc>
-    <lastmod>2026-08-01</lastmod>
+    <lastmod>2026-08-07</lastmod>
     <priority>0.3</priority>
   </url>
 

--- a/scripts/generate-llms.ts
+++ b/scripts/generate-llms.ts
@@ -42,6 +42,16 @@ async function generateLlmsTxt() {
 
     let llmsTxtContent = `\n# llms.txt for ${domain}\n# This file provides structured information for AI language models.\n# For more information, see https://llmstxt.org/\n# Version 1.0, Generated on ${today}\n\n# --- PERMISSIONS ---\nUser-Agent: *\nAllow: /\n\n# --- METADATA ---\nSitemap: https://${domain}/sitemap.xml\n\n# --- FIELDS ---\n\n[Type]:\n[en] Personal Portfolio & CV\n[de] Persönliches Portfolio & Lebenslauf\n\n[Owner]:\n[en] ${content.siteMetadata.author}\n[de] ${content.siteMetadata.author}\n\n[Published]:\n[en] ${today}\n[de] ${today.split('-').reverse().join('.')}\n\n[Languages]:\n[en] English, German\n[de] Englisch, Deutsch\n\n[Summary]:\n${formatBilingual(content.siteMetadata.description)}\n[Hero-Description]:\n${formatBilingual(content.hero.description)}\n[About-Me]:\n${content.about.paragraphs.map(p => formatBilingual(p)).join('')}\n[Main-Topics]:\n${content.navigation.map(item => `- ${item.label.en} / ${item.label.de}`).join('\n')}\n\n[Keywords]:\n[en] ${[content.siteMetadata.author, ...content.hero.titleElements.map(t => t.en), ...content.skills.slice(0, 10).map(s => s.name.en)].join(', ')}\n[de] ${[content.siteMetadata.author, ...content.hero.titleElements.map(t => t.de), ...content.skills.slice(0, 10).map(s => s.name.de)].join(', ')}\n\n[Site-Structure]:\n[en]\n- /: Homepage with main sections (Hero, About, Security & Compliance, Experience, Projects, Skills, Contact).\n- /cv: Interactive page for viewing and downloading the CV.\n- /imprint: Legal notice.\n- /privacy: Privacy policy.\n- /sitemap: Human-readable sitemap.\n[de]\n- /: Startseite mit den Hauptbereichen (Hero, Über Mich, Security & Compliance, Erfahrung, Projekte, Fähigkeiten, Kontakt).\n- /cv: Interaktive Seite zum Ansehen und Herunterladen des Lebenslaufs.\n- /imprint: Impressum.\n- /privacy: Datenschutzerklärung.\n- /sitemap: Für Menschen lesbare Sitemap.\n\n[Contact]:\n[en] Contact information is available via the contact form on the main page or via email to ${content.contact.email}.\n[de] Kontaktinformationen sind über das Kontaktformular auf der Startseite oder per E-Mail an ${content.contact.email} verfügbar.\n`;
 
+    llmsTxtContent += `
+
+## Key Links / Wichtige Links
+- [Homepage](https://${domain}/): Main sections including About, Experience, Projects, Skills, and Contact / Hauptbereiche einschließlich Über Mich, Erfahrung, Projekte, Fähigkeiten und Kontakt.
+- [CV](https://${domain}/cv): Interactive CV and downloads / Interaktiver Lebenslauf und Downloads.
+- [Imprint](https://${domain}/imprint): Legal notice / Impressum.
+- [Privacy](https://${domain}/privacy): Privacy policy / Datenschutzerklärung.
+- [Sitemap](https://${domain}/sitemap): Human-readable sitemap / Für Menschen lesbare Sitemap.
+`;
+
     // Add Security & Compliance / Governance
     llmsTxtContent += '\n# --- SECURITY & COMPLIANCE / GOVERNANCE ---\n';
     llmsTxtContent += `\n[Security-Compliance-Governance]:\n`;

--- a/src/components/ContactSection.test.tsx
+++ b/src/components/ContactSection.test.tsx
@@ -63,4 +63,13 @@ describe("ContactSection", () => {
       }),
     );
   });
+
+  it("keeps decorative social icons out of the accessibility tree", () => {
+    renderWithSettings(<ContactSection />);
+
+    for (const name of ["LinkedIn", "Xing", "Freelancermap"]) {
+      const link = screen.getByRole("link", { name });
+      expect(link.querySelector("svg")).toHaveAttribute("aria-hidden", "true");
+    }
+  });
 });

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -167,7 +167,7 @@ const ContactSection = () => {
                       className="w-10 h-10 rounded-full bg-card border border-border flex items-center justify-center hover:bg-primary hover:text-primary-foreground transition-colors"
                       aria-label="GitHub"
                     >
-                      <SiGithub className="w-5 h-5" />
+                      <SiGithub className="w-5 h-5" aria-hidden="true" focusable="false" />
                     </a>
                   )}
 
@@ -186,6 +186,8 @@ const ContactSection = () => {
                         stroke="currentColor"
                         strokeWidth="2"
                         className="w-5 h-5"
+                        aria-hidden="true"
+                        focusable="false"
                       >
                         <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"></path>
                         <rect width="4" height="12" x="2" y="9"></rect>
@@ -202,7 +204,7 @@ const ContactSection = () => {
                       className="w-10 h-10 rounded-full bg-card border border-border flex items-center justify-center hover:bg-primary hover:text-primary-foreground transition-colors"
                       aria-label="Xing"
                     >
-                      <SiXing className="w-5 h-5" />
+                      <SiXing className="w-5 h-5" aria-hidden="true" focusable="false" />
                     </a>
                   )}
 
@@ -214,7 +216,7 @@ const ContactSection = () => {
                       className="w-10 h-10 rounded-full bg-card border border-border flex items-center justify-center hover:bg-primary hover:text-primary-foreground transition-colors"
                       aria-label="X"
                     >
-                      <SiX className="w-5 h-5" />
+                      <SiX className="w-5 h-5" aria-hidden="true" focusable="false" />
                     </a>
                   )}
 
@@ -226,7 +228,7 @@ const ContactSection = () => {
                       className="w-10 h-10 rounded-full bg-card border border-border flex items-center justify-center hover:bg-primary hover:text-primary-foreground transition-colors"
                       aria-label="Bluesky"
                     >
-                      <SiBluesky className="w-5 h-5" />
+                      <SiBluesky className="w-5 h-5" aria-hidden="true" focusable="false" />
                     </a>
                   )}
 
@@ -238,7 +240,7 @@ const ContactSection = () => {
                       className="w-10 h-10 rounded-full bg-card border border-border flex items-center justify-center hover:bg-primary hover:text-primary-foreground transition-colors"
                       aria-label="Freelancermap"
                     >
-                      <SiFreelancermap className="w-5 h-5" />
+                      <SiFreelancermap className="w-5 h-5" aria-hidden="true" focusable="false" />
                     </a>
                   )}
                 </div>

--- a/src/components/SkillsSection.test.tsx
+++ b/src/components/SkillsSection.test.tsx
@@ -32,4 +32,18 @@ describe("SkillsSection", () => {
     expect(source).toContain("grid-cols-[repeat(auto-fit,minmax(9rem,1fr))]");
     expect(source).toContain("whitespace-normal");
   });
+
+  it("exposes skill levels as accessible meters", () => {
+    renderWithSettings(<SkillsSection />);
+
+    const firstManagementSkill = siteContent.skills.find((skill) => skill.category === "management");
+    expect(firstManagementSkill).toBeDefined();
+
+    const meter = screen.getByRole("meter", {
+      name: `${firstManagementSkill?.name.en} level ${firstManagementSkill?.level} of 5`,
+    });
+    expect(meter).toHaveAttribute("aria-valuemin", "0");
+    expect(meter).toHaveAttribute("aria-valuemax", "5");
+    expect(meter).toHaveAttribute("aria-valuenow", String(firstManagementSkill?.level));
+  });
 });

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -126,13 +126,23 @@ const SkillsGrid = ({ skills }: SkillsGridProps) => {
             key={index}
             className="rounded-lg border border-border bg-card p-3 md:p-4 flex flex-col items-center hover-scale transition-all"
           >
-            <div className="h-10 w-10 rounded-full bg-primary/10 flex items-center justify-center mb-2 md:mb-3 text-primary">
+            <div
+              className="h-10 w-10 rounded-full bg-primary/10 flex items-center justify-center mb-2 md:mb-3 text-primary"
+              aria-hidden="true"
+            >
               <IconComponent className="w-5 h-5" />
             </div>
 
             <h3 className="mb-2 text-center text-sm md:text-base font-medium">{t(skill.name)}</h3>
 
-            <div className="flex gap-1" aria-label={`${t(skill.name)} level ${skill.level} of 5`}>
+            <div
+              className="flex gap-1"
+              role="meter"
+              aria-label={`${t(skill.name)} level ${skill.level} of 5`}
+              aria-valuemin={0}
+              aria-valuemax={5}
+              aria-valuenow={skill.level}
+            >
               {[...Array(5)].map((_, i) => (
                 <div
                   key={i}

--- a/src/tests/llmsTxt.test.ts
+++ b/src/tests/llmsTxt.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("generated llms.txt", () => {
+  const content = readFileSync(path.resolve(process.cwd(), "public/llms.txt"), "utf8");
+
+  it("meets the Lighthouse Agentic Browsing content checks", () => {
+    expect(content.length).toBeGreaterThanOrEqual(50);
+    expect(content).toMatch(/^#\s+.+/m);
+    expect(content).toMatch(/\[[^\]]+\]\([^)]+\)/);
+  });
+
+  it("links to the primary website routes", () => {
+    for (const route of ["/", "/cv", "/imprint", "/privacy", "/sitemap"]) {
+      expect(content).toContain(`https://christianerben.eu${route}`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- expose skill proficiency indicators as accessible meters
- hide decorative social and skill icons from the accessibility tree
- add Lighthouse-recognized Markdown links to the generated `llms.txt`
- add focused regression coverage and refresh generated artifacts

## Verification

- `bun run test:run -- src/components/SkillsSection.test.tsx src/components/ContactSection.test.tsx src/tests/llmsTxt.test.ts`
- `bun run check`
- Lighthouse 13.4.1 with Chrome for Testing 151, `--only-categories=agentic-browsing`: category score 1.0, accessibility tree passed, `llms.txt` passed, CLS 0.011

Closes #153